### PR TITLE
Add code coverage to example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 dist/
 npm-debug.log
 yarn-error.log
+coverage/
 
 # Editor directories and files
 .idea

--- a/package.json
+++ b/package.json
@@ -35,6 +35,15 @@
       "js",
       "vue"
     ],
+    "collectCoverage": true,
+    "collectCoverageFrom": [
+      "**/*.{js,vue}",
+      "!**/node_modules/**"
+    ],
+    "coverageReporters": [
+      "text",
+      "html"
+    ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1"
     },

--- a/package.json
+++ b/package.json
@@ -37,12 +37,9 @@
     ],
     "collectCoverage": true,
     "collectCoverageFrom": [
-      "**/*.{js,vue}",
-      "!**/node_modules/**"
-    ],
-    "coverageReporters": [
-      "text",
-      "html"
+      "/src/**/*.{js,vue}",
+      "!/src/App.vue",
+      "!/src/main.js"
     ],
     "moduleNameMapper": {
       "^@/(.*)$": "<rootDir>/src/$1"


### PR DESCRIPTION
This patch adds some extra configuration to show how coverage can be
generated. This is linked to a similar patch in the primary
vue-test-utils repo, which can be found on this issue:
https://github.com/vuejs/vue-test-utils/issues/165