### PR TITLE
change the import to use the current version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,15 @@
       "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ==",
       "dev": true
     },
+    "@vue/test-utils": {
+      "version": "1.0.0-beta.11",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-1.0.0-beta.11.tgz",
+      "integrity": "sha512-Co8lFJGMRB8yegK3whMlasg9QLeb7zKYjaTyaM4AkKxAwXN0SSYW4NZFOhGVNcnjvRx8KWFfStKM5HQleu3Psw==",
+      "dev": true,
+      "requires": {
+        "lodash": "4.17.4"
+      }
+    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "vue": "^2.4.4"
   },
   "devDependencies": {
+    "@vue/test-utils": "^1.0.0-beta.11",
     "babel-core": "^6.26.0",
     "babel-jest": "^21.2.0",
     "babel-loader": "^7.1.2",
@@ -26,7 +27,6 @@
     "vue-loader": "^13.0.5",
     "vue-server-renderer": "^2.4.4",
     "vue-template-compiler": "^2.4.4",
-    "vue-test-utils": "^1.0.0-beta.8",
     "webpack": "^3.6.0",
     "webpack-dev-server": "^2.9.1"
   },

--- a/test/List.spec.js
+++ b/test/List.spec.js
@@ -1,4 +1,4 @@
-import { shallow } from 'vue-test-utils'
+import { shallow } from '@vue/test-utils'
 import { createRenderer } from 'vue-server-renderer'
 
 import List from '@/components/List.vue'

--- a/test/Message.spec.js
+++ b/test/Message.spec.js
@@ -1,4 +1,4 @@
-import { shallow } from 'vue-test-utils'
+import { shallow } from '@vue/test-utils'
 import Message from '@/components/Message'
 
 describe('Message', () => {

--- a/test/MessageToggle.spec.js
+++ b/test/MessageToggle.spec.js
@@ -1,4 +1,4 @@
-import { shallow } from 'vue-test-utils'
+import { shallow } from '@vue/test-utils'
 import MessageToggle from '@/components/MessageToggle.vue'
 import Message from '@/components/Message'
 


### PR DESCRIPTION
The current version of the code uses the old library import. This reflects the current documentation.