### PR TITLE
Suppress `require-v-for-key` error

### DIFF
--- a/src/components/List.vue
+++ b/src/components/List.vue
@@ -1,6 +1,6 @@
 <template>
   <ul>
-    <li v-for="item in items">
+    <li :key="item" v-for="item in items">
       {{ item }}
     </li>
   </ul>


### PR DESCRIPTION
Suppress error reports on editors integrated with [eslint-plugin-vue](https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/require-v-for-key.md)