### PR TITLE
Fix babel-jest test runner setup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["env", { "modules": false }]
+    [ "env", { "targets": { "browsers": [ "> 1%", "last 2 versions" ] } } ]
   ],
   "env": {
     "test": {

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: node_js
-node_js:
-  - "6"
-  - "8"
-script: "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: node_js
+node_js:
+  - "6"
+  - "8"
+script: "npm test"


### PR DESCRIPTION
When checking out the example project all tests fail due to test-runner compilation issues which resolve around babel/jest not transpiling the code correctly.

When changing `.babelrc` to default to a browser environment everything starts working again.

Maybe there are other solutions. Also, I'd be interested why the current setup seems to be working on some people's computers.

### Environment

```sh
nvm use lts/carbon
# Now using node v8.10.0 (npm v5.6.0)
```

### Steps to reproduce

```sh
git clone https://github.com/vuejs/vue-test-utils-jest-example.git
cd vue-test-utils-jest-example
npm install
npm test
```

### Expected Behavior:
Tests run (but do not necessarily pass)

### Actual Behavior
```txt
 FAIL  test/Message.spec.js
  ● Test suite failed to run

    /home/REDACTED/vue-test-utils-jest-example/test/Message.spec.js:1
    ({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,global,jest){import { shallow } from '@vue/test-utils';
                                                                                             ^^^^^^
    
    SyntaxError: Unexpected token import
      
      at ScriptTransformer._transformAndBuildScript (node_modules/jest-runtime/build/script_transformer.js:305:17)
          at Generator.next (<anonymous>)
          at new Promise (<anonymous>)
```
