### PR TITLE
Adding vue extensions to webpack config

### DIFF
--- a/src/components/MessageToggle.vue
+++ b/src/components/MessageToggle.vue
@@ -8,7 +8,7 @@
 </template>
 
 <script>
-import Message from './Message'
+import Message from '@/components/Message.vue'
 
 export default {
   name: 'message-toggle',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,7 +37,8 @@ module.exports = {
     alias: {
       'vue$': 'vue/dist/vue.esm.js',
       '@': path.resolve(__dirname, 'src')
-    }
+    },
+    extensions: ['*', '.js', '.vue', '.json']
   },
   devServer: {
     historyApiFallback: true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,8 +37,7 @@ module.exports = {
     alias: {
       'vue$': 'vue/dist/vue.esm.js',
       '@': path.resolve(__dirname, 'src')
-    },
-    extensions: ['*', '.js', '.vue', '.json']
+    }
   },
   devServer: {
     historyApiFallback: true,


### PR DESCRIPTION
Adding vue extensions to webpack config file in order to fix the following error when running `npm run dev` or `npm run build`:

```
Module not found: Error: Can't resolve './Message'
```