### PR TITLE
Small update on deprecated configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ The following configurations are recommended for Jest:
     // serializer for snapshots
     "snapshotSerializers": [
       "<rootDir>/node_modules/jest-serializer-vue"
-    ],
-    "mapCoverage": true
+    ]
   }
 }
 ```


### PR DESCRIPTION
Remove deprecated configuration on README
```
● Deprecation Warning:

  Option "mapCoverage" has been removed, as it's no longer necessary.

  Please update your configuration.

  Configuration Documentation:
  https://facebook.github.io/jest/docs/configuration.html
```