### PR TITLE
chore: bump up test-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "vue": "^2.4.4"
   },
   "devDependencies": {
-    "@vue/test-utils": "^1.0.0-beta.11",
+    "@vue/test-utils": "^1.0.0-beta.16",
     "babel-core": "^6.26.0",
     "babel-jest": "^21.2.0",
     "babel-loader": "^7.1.2",
@@ -44,7 +44,6 @@
     },
     "snapshotSerializers": [
       "<rootDir>/node_modules/jest-serializer-vue"
-    ],
-    "mapCoverage": true
+    ]
   }
 }

--- a/test/List.spec.js
+++ b/test/List.spec.js
@@ -1,10 +1,10 @@
-import { shallow } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import List from '@/components/List.vue'
 
 describe('List.vue', () => {
   it('renders li for each item in props.items', () => {
-    const items = ['', '']
-    const wrapper = shallow(List, {
+    const items = ['1', '2']
+    const wrapper = shallowMount(List, {
       propsData: { items }
     })
     expect(wrapper.findAll('li')).toHaveLength(items.length)
@@ -12,7 +12,7 @@ describe('List.vue', () => {
 
   it('matches snapshot', () => {
     const items = ['item 1', 'item 2']
-    const wrapper = shallow(List, {
+    const wrapper = shallowMount(List, {
       propsData: { items }
     })
     expect(wrapper.html()).toMatchSnapshot()

--- a/test/Message.spec.js
+++ b/test/Message.spec.js
@@ -1,10 +1,10 @@
-import { shallow } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import Message from '@/components/Message.vue'
 
 describe('Message', () => {
   it('renders props.msg when passed', () => {
     const msg = 'new message'
-    const wrapper = shallow(Message, {
+    const wrapper = shallowMount(Message, {
       propsData: { msg }
     })
     expect(wrapper.text()).toBe(msg)
@@ -12,7 +12,7 @@ describe('Message', () => {
 
   it('renders default message if not passed a prop', () => {
     const defaultMessage = 'default message'
-    const wrapper = shallow(Message)
+    const wrapper = shallowMount(Message)
     expect(wrapper.text()).toBe(defaultMessage)
   })
 })

--- a/test/MessageToggle.spec.js
+++ b/test/MessageToggle.spec.js
@@ -1,10 +1,10 @@
-import { shallow } from '@vue/test-utils'
+import { shallowMount } from '@vue/test-utils'
 import MessageToggle from '@/components/MessageToggle.vue'
 import Message from '@/components/Message.vue'
 
 describe('MessageToggle.vue', () => {
   it('toggles msg passed to Message when button is clicked', () => {
-    const wrapper = shallow(MessageToggle)
+    const wrapper = shallowMount(MessageToggle)
     const button = wrapper.find('#toggle-message')
     button.trigger('click')
     const MessageComponent = wrapper.find(Message)

--- a/yarn.lock
+++ b/yarn.lock
@@ -10,6 +10,12 @@
   version "0.0.30"
   resolved "https://registry.yarnpkg.com/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz#9aa30c04db212a9a0649d6ae6fd50accc40748a1"
 
+"@vue/test-utils@^1.0.0-beta.16":
+  version "1.0.0-beta.16"
+  resolved "https://registry.yarnpkg.com/@vue/test-utils/-/test-utils-1.0.0-beta.16.tgz#dcf7a30304391422e382b5f97db6eb9508112906"
+  dependencies:
+    lodash "^4.17.4"
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -5188,12 +5194,6 @@ vue-template-compiler@^2.4.4:
 vue-template-es2015-compiler@^1.5.3, vue-template-es2015-compiler@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.6.0.tgz#dc42697133302ce3017524356a6c61b7b69b4a18"
-
-vue-test-utils@^1.0.0-beta.1:
-  version "1.0.0-beta.8"
-  resolved "https://registry.yarnpkg.com/vue-test-utils/-/vue-test-utils-1.0.0-beta.8.tgz#b4f84ce36f7ae457cdbab9ba21771f4a50d4dabd"
-  dependencies:
-    lodash "^4.17.4"
 
 vue@^2.4.4:
   version "2.5.13"


### PR DESCRIPTION
# Summary

This PR is to bump up `@vue/test-utils`, since the `shallow` API has been deprecated but user would download the latest version(`1.0.0-beta.16`).